### PR TITLE
Improve generalizable use

### DIFF
--- a/biscuit/__init__.py
+++ b/biscuit/__init__.py
@@ -7,4 +7,4 @@ from biscuit.utils import find_cv, get_model_results
 from biscuit.experiment import train, train_nested_cv, plot_uq_calibration, \
                                thresholds_from_nested_cv
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -95,15 +95,13 @@ def train_nested_cv(project, hp, label, outer_k=3, inner_k=5,
             if not utils.model_exists(project, f'{label}-k{ki+1}', kfold=k)
         ]
         if not len(inner_k_to_run):
-            msg = f'Skipping nested cross-val (inner k{ki+1} for experiment '
-            msg += f'{label}; already done.'
-            print(msg)
+            print(f'Skipping nested cross-val (inner k{ki+1} for experiment '
+                  f'{label}; already done.')
         else:
             if inner_k_to_run != list(range(1, inner_k+1)):
-                msg = f'Only running k-folds {inner_k_to_run} for nested '
-                msg += f'cross-val k{ki+1} in experiment {label}; '
-                msg += 'some k-folds already done.'
-                print(msg)
+                print(f'Only running k-folds {inner_k_to_run} for nested '
+                      f'cross-val k{ki+1} in experiment {label}; '
+                      'some k-folds already done.')
             train_slides = sf.util.get_slides_from_model_manifest(
                 k_model, dataset='training'
             )
@@ -180,7 +178,7 @@ def plot_uq_calibration(project, label, tile_uq, slide_uq, slide_pred,
 
 
 def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
-                              threshold_params=None, outcome=None):
+                              threshold_params=None, outcome=None, epoch=1):
     """Detects tile- and slide-level UQ thresholds and slide-level prediction
     thresholds from nested cross-validation."""
 
@@ -202,19 +200,27 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
     all_slide_pred_thresh = []
     df = pd.DataFrame()
     for k in range(1, outer_k+1):
-        cv_dirs = utils.find_cv(
-            project,
-            f'{label}-k{k}',
-            k=inner_k,
-            outcome=outcome
-        )
-        k_preds = [join(f, 'tile_predictions_val_epoch1.csv') for f in cv_dirs]
+        try:
+            cv_dirs = utils.find_cv(
+                project,
+                f'{label}-k{k}',
+                k=inner_k,
+                outcome=outcome
+            )
+        except ModelNotFoundError:
+            log.warn(f"Could not find {label} k-fold {k}; skipping")
+            continue
+        k_preds = [
+            join(f, f'tile_predictions_val_epoch{epoch}.csv')
+            for f in cv_dirs
+        ]
         val_path = join(
             utils.find_model(project, f'{label}', kfold=k, outcome=outcome),
-            'tile_predictions_val_epoch1.csv'
+            f'tile_predictions_val_epoch{epoch}.csv'
         )
         if not exists(val_path):
-            raise FileNotFoundError
+            log.warn(f"Could not find {label} k-fold {k}; skipping")
+            continue
         tile_uq, *_ = threshold.from_cv(
             k_preds,
             tile_uq_thresh='detect',
@@ -239,7 +245,7 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         }
         tile_pred_df.rename(columns=rename_cols, inplace=True)
 
-        def get_auc_by_level(level):
+        def uq_auc_by_level(level):
             auc, perc, _, _, _ = threshold.apply(
                 tile_pred_df,
                 thresh_tile=tile_uq,
@@ -252,8 +258,8 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
             )
             return auc, perc
 
-        pt_auc, pt_perc = get_auc_by_level('patient')
-        slide_auc, slide_perc = get_auc_by_level('slide')
+        pt_auc, pt_perc = uq_auc_by_level('patient')
+        slide_auc, slide_perc = uq_auc_by_level('slide')
         model = utils.find_model(
             project,
             f'{label}',
@@ -598,7 +604,7 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
             continue
         for i, m in enumerate(models):
             try:
-                results = utils.get_model_results(m)
+                results = utils.get_model_results(m, epoch=1)
             except FileNotFoundError:
                 print(f"Unable to open cross-val results for {exp}; skipping")
                 continue
@@ -626,7 +632,7 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
         all_pred_thresh = []
         for i, m in enumerate(models):
             try:
-                results = utils.get_model_results(m)
+                results = utils.get_model_results(m, epoch=1)
                 all_pred_thresh += [results['opt_thresh']]
                 df = df.append({
                     'id': exp,
@@ -692,7 +698,7 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                 # Read and prepare model results
                 try:
                     eval_dir = utils.find_eval(val_P, f'EXP_{exp}_FULL')
-                    results = utils.get_model_results(eval_dir)
+                    results = utils.get_model_results(eval_dir, epoch=1)
                 except (FileNotFoundError, MatchError):
                     log.debug(f"Skipping eval for exp {exp}; eval not found")
                     continue
@@ -777,6 +783,7 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                             thresh_slide = slide_uq_thresholds[exp]
 
                             val_patients = val_P.dataset(verification=None).patients()
+
                             def get_metrics_by_level(level):
                                 return threshold.apply(
                                     tile_pred_df,

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -226,22 +226,21 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         if not exists(val_path):
             log.warn(f"Could not find {label} k-fold {k}; skipping")
             continue
-        tile_uq, *_ = threshold.from_cv(
+        tile_uq = threshold.from_cv(
             dfs,
             tile_uq_thresh='detect',
             slide_uq_thresh=None,
             **threshold_params
-        )
+        )['tile_uq']
         thresholds = threshold.from_cv(
             dfs,
             tile_uq_thresh=tile_uq,
             slide_uq_thresh='detect',
             **threshold_params
         )
-        _, slide_uq, tile_pred, slide_pred = thresholds
         all_tile_uq_thresh += [tile_uq]
-        all_slide_uq_thresh += [slide_uq]
-        all_slide_pred_thresh += [slide_pred]
+        all_slide_uq_thresh += [thresholds['slide_uq']]
+        all_slide_pred_thresh += [thresholds['slide_pred']]
         if sf.util.path_to_ext(val_path).lower() == 'csv':
             tile_pred_df = pd.read_csv(val_path, dtype={'slide': str})
         elif sf.util.path_to_ext(val_path).lower() in ('parquet', 'gzip'):
@@ -260,9 +259,9 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
             auc, perc, *_ = threshold.apply(
                 tile_pred_df,
                 thresh_tile=tile_uq,
-                thresh_slide=slide_uq,
-                tile_pred_thresh=tile_pred,
-                slide_pred_thresh=slide_pred,
+                thresh_slide=thresholds['slide_uq'],
+                tile_pred_thresh=thresholds['tile_pred'],
+                slide_pred_thresh=thresholds['slide_pred'],
                 plot=False,
                 patients=patients,
                 level=level

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -257,7 +257,7 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         tile_pred_df.rename(columns=rename_cols, inplace=True)
 
         def uq_auc_by_level(level):
-            auc, perc, _, _, _ = threshold.apply(
+            auc, perc, *_ = threshold.apply(
                 tile_pred_df,
                 thresh_tile=tile_uq,
                 thresh_slide=slide_uq,
@@ -809,8 +809,8 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                                     level=level
                                 )
 
-                            s_uq_auc, s_uq_perc, s_uq_acc, s_uq_sens, s_uq_spec = get_metrics_by_level('slide')
-                            p_uq_auc, p_uq_perc, p_uq_acc, p_uq_sens, p_uq_spec = get_metrics_by_level('patient')
+                            s_uq_auc, s_uq_perc, s_uq_acc, s_uq_sens, s_uq_spec, _ = get_metrics_by_level('slide')
+                            p_uq_auc, p_uq_perc, p_uq_acc, p_uq_sens, p_uq_spec, _ = get_metrics_by_level('patient')
                             if (plot and keep == 'high_confidence' and exp == 'AA'):
                                 plt.savefig(join(OUT, f'{name}_uncertainty_v_preds.svg'))
 

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -258,13 +258,10 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         def uq_auc_by_level(level):
             auc, perc, *_ = threshold.apply(
                 tile_pred_df,
-                thresh_tile=tile_uq,
-                thresh_slide=thresholds['slide_uq'],
-                tile_pred_thresh=thresholds['tile_pred'],
-                slide_pred_thresh=thresholds['slide_pred'],
                 plot=False,
                 patients=patients,
-                level=level
+                level=level,
+                **thresholds
             )
             return auc, perc
 
@@ -797,10 +794,10 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                             def get_metrics_by_level(level):
                                 return threshold.apply(
                                     tile_pred_df,
-                                    thresh_tile=thresh_tile,
-                                    thresh_slide=thresh_slide,
-                                    tile_pred_thresh=0.5,
-                                    slide_pred_thresh=pred_uq_thresholds[exp],
+                                    tile_uq=thresh_tile,
+                                    slide_uq=thresh_slide,
+                                    tile_pred=0.5,
+                                    slide_pred=pred_uq_thresholds[exp],
                                     plot=(plot and keep == 'high_confidence' and exp == 'AA'),
                                     title=f'{name}: Exp. {exp} Uncertainty',
                                     keep=keep,  # Keeps only LOW or HIGH-confidence slide predictions

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -256,14 +256,14 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         tile_pred_df.rename(columns=rename_cols, inplace=True)
 
         def uq_auc_by_level(level):
-            auc, perc, *_ = threshold.apply(
+            results, _ = threshold.apply(
                 tile_pred_df,
                 plot=False,
                 patients=patients,
                 level=level,
                 **thresholds
             )
-            return auc, perc
+            return results['auc'], results['percent_incl']
 
         pt_auc, pt_perc = uq_auc_by_level('patient')
         slide_auc, slide_perc = uq_auc_by_level('slide')
@@ -805,8 +805,8 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                                     level=level
                                 )
 
-                            s_uq_auc, s_uq_perc, s_uq_acc, s_uq_sens, s_uq_spec, _ = get_metrics_by_level('slide')
-                            p_uq_auc, p_uq_perc, p_uq_acc, p_uq_sens, p_uq_spec, _ = get_metrics_by_level('patient')
+                            s_results, _ = get_metrics_by_level('slide')
+                            p_results, _ = get_metrics_by_level('patient')
                             if (plot and keep == 'high_confidence' and exp == 'AA'):
                                 plt.savefig(join(OUT, f'{name}_uncertainty_v_preds.svg'))
 
@@ -816,18 +816,18 @@ def results(exp_to_run, uq=True, eval=True, plot=False):
                                 'id': exp,
                                 'n_slides': n_slides,
                                 'uq': ('include' if keep == 'high_confidence' else 'exclude'),
-                                'slide_incl': s_uq_perc,
-                                'slide_auc': s_uq_auc,
-                                'slide_acc': s_uq_acc,
-                                'slide_sens': s_uq_sens,
-                                'slide_spec': s_uq_spec,
-                                'slide_youden': s_uq_sens + s_uq_spec - 1,
-                                'patient_incl': p_uq_perc,
-                                'patient_auc': p_uq_auc,
-                                'patient_acc': p_uq_acc,
-                                'patient_sens': p_uq_sens,
-                                'patient_spec': p_uq_spec,
-                                'patient_youden': p_uq_sens + p_uq_spec - 1
+                                'slide_incl': s_results['percent_incl'],
+                                'slide_auc': s_results['auc'],
+                                'slide_acc': s_results['acc'],
+                                'slide_sens': s_results['sensitivity'],
+                                'slide_spec': s_results['specificity'],
+                                'slide_youden': s_results['sensitivity'] + s_results['specificity'] - 1,
+                                'patient_incl': p_results['percent_incl'],
+                                'patient_auc': p_results['auc'],
+                                'patient_acc': p_results['acc'],
+                                'patient_sens': p_results['sensitivity'],
+                                'patient_spec': p_results['specificity'],
+                                'patient_youden': p_results['sensitivity'] + p_results['specificity'] - 1,
                             }, ignore_index=True)
         for eval_name in eval_dfs:
             eval_dfs[eval_name].to_csv(

--- a/biscuit/experiment.py
+++ b/biscuit/experiment.py
@@ -291,9 +291,9 @@ def thresholds_from_nested_cv(project, label, outer_k=3, inner_k=5, id=None,
         }, ignore_index=True)
 
     thresholds = {
-        'tile_uq': mean(all_tile_uq_thresh),
-        'slide_uq': mean(all_slide_uq_thresh),
-        'slide_pred': mean(all_slide_pred_thresh),
+        'tile_uq': None if not all_tile_uq_thresh else mean(all_tile_uq_thresh),
+        'slide_uq': None if not all_tile_uq_thresh else mean(all_slide_uq_thresh),
+        'slide_pred': None if not all_tile_uq_thresh else mean(all_slide_pred_thresh),
     }
     return df, thresholds
 
@@ -996,6 +996,8 @@ def display(df, eval_dfs, hue='uq', palette='tab10', relplot_uq_compare=True,
 
     if eval_dfs:
         for eval_name, eval_df in eval_dfs.items():
+            if not len(eval_df):
+                continue
             has_uq = len(eval_df.loc[eval_df['uq'].isin(['include', 'exclude'])])
 
             # Prepare figure

--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -1,12 +1,12 @@
-import numpy as np
 import matplotlib.pyplot as plt
-import seaborn as sns
+import numpy as np
 import pandas as pd
-from skmisc.loess import loess
+import seaborn as sns
 from sklearn import metrics
-
+from skmisc.loess import loess
 from slideflow.util import log
-from biscuit import utils, errors
+
+from biscuit import errors, utils
 
 
 def plot_uncertainty(df, kind, threshold=None, title=None):
@@ -47,10 +47,10 @@ def plot_uncertainty(df, kind, threshold=None, title=None):
     axes[0].title.set_text(f'Uncertainty density ({kind}-level)')
 
     # Middle figure - Scatter -------------------------------------------------
-    axes[1].axhline(y=threshold, color='r', linestyle='--')
 
     # - Above threshold
     if threshold is not None:
+        axes[1].axhline(y=threshold, color='r', linestyle='--')
         at_df = df.loc[(df['uncertainty'] >= threshold)]
         c_a_df = at_df.loc[at_df['correct']]
         ic_a_df = at_df.loc[~at_df['correct']]
@@ -64,7 +64,7 @@ def plot_uncertainty(df, kind, threshold=None, title=None):
         axes[1].scatter(
             x=ic_a_df['y_pred'],
             y=ic_a_df['uncertainty'],
-            marker='x',
+            marker='v',
             color='#FC6D77'
         )
     # - Below threshold
@@ -83,7 +83,8 @@ def plot_uncertainty(df, kind, threshold=None, title=None):
     axes[1].scatter(
         x=ic_df['y_pred'],
         y=ic_df['uncertainty'],
-        marker='x',
+        marker='v',
+        s=10,
         color='red'
     )
     if title is not None:
@@ -105,7 +106,8 @@ def plot_uncertainty(df, kind, threshold=None, title=None):
     axes[2].fill_between(x, ll, ul, alpha=.2)
     axes[2].tick_params(labelrotation=90)
     axes[2].set_ylim(-0.1, 1.1)
-    axes[2].axvline(x=threshold, color='r', linestyle='--')
+    if threshold is not None:
+        axes[2].axvline(x=threshold, color='r', linestyle='--')
 
     # - Figure style
     for ax in (axes[1], axes[2]):
@@ -167,6 +169,7 @@ def process_tile_predictions(df, pred_thresh=0.5, patients=None):
     df['incorrect'] = (~df['correct']).astype(int)
     df['y_pred_bin'] = (df['y_pred'] >= pred_thresh).astype(int)
     return df, pred_thresh
+
 
 def process_group_predictions(df, pred_thresh, level):
     '''From a given dataframe of tile-level predictions, calculate group-level
@@ -290,7 +293,7 @@ def apply(df, thresh_tile, thresh_slide, tile_pred_thresh=0.5,
             level=level
         )
     except errors.ROCFailedError:
-        log.error(f"Unable to process slide predictions")
+        log.error("Unable to process slide predictions")
         return None, None, None, None, None
 
     if plot:
@@ -328,7 +331,7 @@ def apply(df, thresh_tile, thresh_slide, tile_pred_thresh=0.5,
     log.debug(f"Sensitivity: {sensitivity:.4f}")
     log.debug(f"Specificity: {specificity:.4f}")
 
-    return auc, percent_incl, acc, sensitivity, specificity
+    return auc, percent_incl, acc, sensitivity, specificity, s_df
 
 
 def detect(df, tile_uq_thresh='detect', slide_uq_thresh='detect',
@@ -371,7 +374,7 @@ def detect(df, tile_uq_thresh='detect', slide_uq_thresh='detect',
             patients=patients
         )
     except errors.PredsContainNaNError:
-        log.error(f"Tile-level predictions contain NaNs; unable to process.")
+        log.error("Tile-level predictions contain NaNs; unable to process.")
         return None, None, None, None, None
 
     # Tile-level ROC and Youden's J

--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -264,7 +264,7 @@ def apply(df, tile_uq, slide_uq, tile_pred=0.5,
         Dictionary of results, with keys auc, percent_incl, accuracy,
             sensitivity, and specificity
 
-        DataFrame of thresholded predictions
+        DataFrame of thresholded group-level predictions
     '''
 
     assert keep in ('high_confidence', 'low_confidence')

--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -261,7 +261,7 @@ def apply(df, thresh_tile, thresh_slide, tile_pred_thresh=0.5,
             Defaults to 'slide'.
 
     Returns:
-        auc, percent_incl, accuracy, sensitivity, specificity
+        auc, percent_incl, accuracy, sensitivity, specificity, DataFrame
     '''
 
     assert keep in ('high_confidence', 'low_confidence')
@@ -295,7 +295,7 @@ def apply(df, thresh_tile, thresh_slide, tile_pred_thresh=0.5,
         )
     except errors.ROCFailedError:
         log.error("Unable to process slide predictions")
-        return None, None, None, None, None
+        return None, None, None, None, None, None
 
     if plot:
         plot_uncertainty(s_df, threshold=thresh_slide, kind=level, title=title)

--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -261,7 +261,10 @@ def apply(df, tile_uq, slide_uq, tile_pred=0.5,
             Defaults to 'slide'.
 
     Returns:
-        auc, percent_incl, accuracy, sensitivity, specificity, DataFrame
+        Dictionary of results, with keys auc, percent_incl, accuracy,
+            sensitivity, and specificity
+
+        DataFrame of thresholded predictions
     '''
 
     assert keep in ('high_confidence', 'low_confidence')
@@ -332,7 +335,14 @@ def apply(df, tile_uq, slide_uq, tile_pred=0.5,
     log.debug(f"Sensitivity: {sensitivity:.4f}")
     log.debug(f"Specificity: {specificity:.4f}")
 
-    return auc, percent_incl, acc, sensitivity, specificity, s_df
+    results = {
+        'auc': auc,
+        'percent_incl': percent_incl,
+        'acc': acc,
+        'sensitivity': sensitivity,
+        'specificity': specificity
+    }
+    return results, s_df
 
 
 def detect(df, tile_uq='detect', slide_uq='detect', tile_pred='detect',

--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -463,16 +463,16 @@ def from_cv(dfs, **kwargs):
             and 'patient'.
 
     Keyword args:
-        tile_uq_thresh (str or float): Either 'detect' or float. If 'detect',
+        tile_uq (str or float): Either 'detect' or float. If 'detect',
             will detect tile-level uncertainty threshold. If float, will use
             the specified tile-level uncertainty threshold.
-        slide_uq_thresh (str or float): Either 'detect' or float. If 'detect',
+        slide_uq (str or float): Either 'detect' or float. If 'detect',
             will detect slide-level uncertainty threshold. If float, will use
             the specified slide-level uncertainty threshold.
-        tile_pred_thresh (str or float): Either 'detect' or float. If 'detect',
+        tile_pred (str or float): Either 'detect' or float. If 'detect',
             will detect tile-level prediction threshold. If float, will use the
             specified tile-level prediction threshold.
-        slide_pred_thresh (str or float): Either 'detect' or float. If 'detect'
+        slide_pred (str or float): Either 'detect' or float. If 'detect'
             will detect slide-level prediction threshold. If float, will use
             the specified slide-level prediction threshold.
         plot (bool, optional): Plot slide-level uncertainty. Defaults to False.

--- a/biscuit/utils.py
+++ b/biscuit/utils.py
@@ -1,17 +1,18 @@
-import os
 import csv
+import os
 import shutil
-import pandas as pd
-import numpy as np
-import slideflow as sf
-import matplotlib.colors as colors
-
-from biscuit.errors import MultipleModelsFoundError, ModelNotFoundError
-from biscuit.delong import delong_roc_variance
-from sklearn import metrics
-from scipy import stats
-from statistics import mean, variance
 from os.path import join
+from statistics import mean, variance
+
+import matplotlib.colors as colors
+import numpy as np
+import pandas as pd
+import slideflow as sf
+from scipy import stats
+from sklearn import metrics
+
+from biscuit.delong import delong_roc_variance
+from biscuit.errors import ModelNotFoundError, MultipleModelsFoundError
 
 OUTCOME = 'cohort'
 OUTCOME1 = 'LUAD'
@@ -47,7 +48,7 @@ def truncate_colormap(cmap, minval=0.0, maxval=1.0, n=100):
     return new_cmap
 
 
-def get_model_results(path, outcome=None):
+def get_model_results(path, epoch, outcome=None):
     """Reads results/metrics from a trained model.
 
     Args:
@@ -62,14 +63,25 @@ def get_model_results(path, outcome=None):
     if outcome is None:
         outcome = OUTCOME
     csv = pd.read_csv(join(path, 'results_log.csv'))
-    model_res = next(csv.iterrows())[1]
+    result_rows = {}
+    for i, row in csv.iterrows():
+        row_epoch = int(row['model_name'].split('epoch')[-1])
+        result_rows.update({
+            row_epoch: row
+        })
+    if epoch not in result_rows:
+        raise ModelNotFoundError(f"Unable to find results for epoch {epoch}")
+    model_res = result_rows[epoch]
     pt_ap = mean(eval(model_res['patient_ap'])[outcome])
     pt_auc = eval(model_res['patient_auc'])[outcome][0]
     slide_ap = mean(eval(model_res['slide_ap'])[outcome])
     slide_auc = eval(model_res['slide_auc'])[outcome][0]
     tile_ap = mean(eval(model_res['tile_ap'])[outcome])
     tile_auc = eval(model_res['tile_auc'])[outcome][0]
-    pred_path = join(path, f'patient_predictions_{OUTCOME}_val_epoch1.csv')
+    pred_path = join(
+        path,
+        f'patient_predictions_{outcome}_val_epoch{epoch}.csv'
+    )
     if os.path.exists(pred_path):
         _, opt_thresh = auc_and_threshold(*read_group_predictions(pred_path))
     else:
@@ -143,11 +155,11 @@ def find_model(project, label, epoch=None, kfold=None, outcome=None):
         if o[6:] == model_name
     ]
     if len(matching) > 1:
-        msg = f"Multiple matching models found matching {model_name}"
-        raise MultipleModelsFoundError(msg)
+        raise MultipleModelsFoundError("Multiple matching models found "
+                                       f"matching {model_name}")
     elif not len(matching):
-        msg = f"No matching model found matching {model_name}."
-        raise ModelNotFoundError(msg)
+        raise ModelNotFoundError("No matching model found matching "
+                                 f"{model_name}.")
     elif epoch is not None:
         return join(
             project.models_dir,
@@ -223,8 +235,8 @@ def find_eval(project, label, epoch=1, outcome=None):
         if o[11:] == f'{OUTCOME}-{label}-HP0_epoch{epoch}'
     ]
     if len(matching) > 1:
-        msg = f"Multiple matching eval experiments found for label {label}"
-        raise MultipleModelsFoundError(msg)
+        raise MultipleModelsFoundError("Multiple matching eval experiments "
+                                       f"found for label {label}")
     elif not len(matching):
         raise ModelNotFoundError(f"No matching eval found for label {label}")
     else:

--- a/biscuit/utils.py
+++ b/biscuit/utils.py
@@ -63,7 +63,10 @@ def get_model_results(path, epoch, outcome=None):
     csv = pd.read_csv(join(path, 'results_log.csv'))
     result_rows = {}
     for i, row in csv.iterrows():
-        row_epoch = int(row['model_name'].split('epoch')[-1])
+        try:
+            row_epoch = int(row['model_name'].split('epoch')[-1])
+        except ValueError:
+            continue
         result_rows.update({
             row_epoch: row
         })

--- a/results.py
+++ b/results.py
@@ -120,24 +120,13 @@ def show_results(train_project=None, eval_project=None, reg=False, ratio=False,
             raise ModelNotFoundError("Couldn't find trained model EXP_AA_FULL")
         aa_model = utils.find_model(P, 'EXP_AA_FULL', epoch=1)
 
-        # Get tile uncertainty threshold
-        threshold_params = {
-            'y_pred_header':        utils.y_pred_header(),
-            'y_true_header':        utils.y_true_header(),
-            'uncertainty_header':   utils.uncertainty_header(),
-            'patients':             P.dataset().patients()
-        }
         all_tile_uq_thresh = []
         for k in range(1, 4):
-            k_preds = [
-                join(folder, 'tile_predictions_val_epoch1.csv')
-                for folder in utils.find_cv(P, f'EXP_AA_UQ-k{k}', k=5)
-            ]
             tile_uq, *_ = threshold.from_cv(
-                k_preds,
+                utils.df_from_cv(P, f'EXP_AA_UQ-k{k}', k=5),
                 tile_uq_thresh='detect',
                 slide_uq_thresh=None,
-                **threshold_params
+                patients=P.dataset().patients()
             )
             all_tile_uq_thresh += [tile_uq]
         aa_tile_uq_thresh = mean(all_tile_uq_thresh)

--- a/results.py
+++ b/results.py
@@ -122,12 +122,12 @@ def show_results(train_project=None, eval_project=None, reg=False, ratio=False,
 
         all_tile_uq_thresh = []
         for k in range(1, 4):
-            tile_uq, *_ = threshold.from_cv(
+            tile_uq = threshold.from_cv(
                 utils.df_from_cv(P, f'EXP_AA_UQ-k{k}', k=5),
                 tile_uq_thresh='detect',
                 slide_uq_thresh=None,
                 patients=P.dataset().patients()
-            )
+            )['tile_uq']
             all_tile_uq_thresh += [tile_uq]
         aa_tile_uq_thresh = mean(all_tile_uq_thresh)
 

--- a/results.py
+++ b/results.py
@@ -212,9 +212,9 @@ def show_results(train_project=None, eval_project=None, reg=False, ratio=False,
 
     # --- Plot UMAPs (Figure 5) -----------------------------------------------
     if umaps:
-
-        df = cP.generate_features(aa_model, max_tiles=10)
-        mosaic = cP.generate_mosaic(df)
+        filters = {'cohort': ['LUAD', 'LUSC']}
+        df = cP.generate_features(aa_model, filters=filters, max_tiles=10, cache='act.pkl')
+        mosaic = cP.generate_mosaic(df, filters=filters, umap_cache='umap.pkl', use_norm=False)
 
         # Figure 5a
         mosaic.save(join('results', 'mosaic.png'))
@@ -236,6 +236,11 @@ def show_results(train_project=None, eval_project=None, reg=False, ratio=False,
         # Figure 5e
         mosaic.slide_map.labels = mosaic.slide_map.labels < aa_tile_uq_thresh
         mosaic.slide_map.save(join('results', 'umap_confidence.svg'), s=10)
+
+        # Showing ground-truth labels
+        labels, _ = cP.dataset().labels('cohort')
+        mosaic.slide_map.label_by_slide(labels)
+        mosaic.slide_map.save(join('results', 'umap_labels.svg'), s=10)
 
     # --- Analyze GAN (overview, non-UQ) (Figure 6)----------------------------
     if gan:


### PR DESCRIPTION
- `threshold.from_cv()` now takes DataFrames as arguments, rather than paths to CSV files, for improved generalizability
- `threshold.from_cv()` returns results as a dict rather than tuple
- `threshold.apply()` returns results as a dict
- Unify arguments for `threshold.apply()` and `.detect()`
- Early support for predictions in parquet storage (will be required for Slideflow 1.2 compatibility)
- Support for experiments at epochs other than 1
- Error handling and error message improvements
- README updates
- Version increase to 0.1.1