### PR TITLE
Bug fix with prediction threshold reporting from cross-validation [#3]

### DIFF
--- a/biscuit/threshold.py
+++ b/biscuit/threshold.py
@@ -527,8 +527,8 @@ def from_cv(dfs, **kwargs):
             log.debug(f"Skipping CV #{idx}, unable to detect threshold")
             continue
 
-        k_tile_pred_thresh += [thresholds['slide_pred']]
-        k_slide_pred_thresh += [thresholds['tile_pred']]
+        k_tile_pred_thresh += [thresholds['tile_pred']]
+        k_slide_pred_thresh += [thresholds['slide_pred']]
         k_auc += [auc]
 
         if not skip_tile:


### PR DESCRIPTION
- Fix bug where tile and slide prediction thresholds were swapped during detection from cross-validation